### PR TITLE
fix(git): use machine-local gitconfig in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ script/bootstrap
 ```
 This will symlink the appropriate files in .dotfiles to your home directory. Everything is configured and tweaked within ~/.dotfiles and changes are reflected immediately once updated profiles are reloaded.
 
+Bootstrap prompts for your Git author name and email, then creates the ignored
+`git/gitconfig.local.symlink` with those values and the platform-appropriate
+credential helper. The tracked global Git configuration includes this file as
+`~/.gitconfig.local`, keeping machine-specific settings out of the repository.
+
 ## Testing
 To ensure the dotfiles are installing correctly and prevent regressions:
 ```zsh

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,7 +1,5 @@
-[github]
-  user = jamieshark
-[credential]
-  helper = osxkeychain
+[include]
+  path = ~/.gitconfig.local
 [core]
   editor = code --wait
   excludesfile = "$HOME/.gitignore"
@@ -84,9 +82,6 @@
 [push]
   default = simple
   autoSetupRemote = true
-[user]
-	name = Jamie Shark
-	email = 5520141+jamieshark@users.noreply.github.com
 [filter "lfs"]
 	process = git-lfs filter-process
 	required = true

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -37,18 +37,29 @@ setup_gitconfig () {
   then
     info 'setup gitconfig'
 
-    git_credential='cache'
+    local gitconfig_local='git/gitconfig.local.symlink'
+    local gitconfig_temp git_authorname git_authoremail
+    local git_credential='cache'
     if [ "$(uname -s)" == "Darwin" ]
     then
       git_credential='osxkeychain'
     fi
 
     user ' - What is your github author name?'
-    read -e git_authorname
+    read -r -e git_authorname
     user ' - What is your github author email?'
-    read -e git_authoremail
+    read -r -e git_authoremail
 
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.local.symlink.example > git/gitconfig.local.symlink
+    gitconfig_temp=$(mktemp "${gitconfig_local}.XXXXXX")
+    if ! cp git/gitconfig.local.symlink.example "$gitconfig_temp" ||
+      ! git config --file "$gitconfig_temp" user.name "$git_authorname" ||
+      ! git config --file "$gitconfig_temp" user.email "$git_authoremail" ||
+      ! git config --file "$gitconfig_temp" credential.helper "$git_credential"
+    then
+      rm -f "$gitconfig_temp"
+      fail 'unable to create gitconfig'
+    fi
+    mv "$gitconfig_temp" "$gitconfig_local"
 
     success 'gitconfig'
   fi

--- a/test/README.md
+++ b/test/README.md
@@ -36,6 +36,7 @@ The test script will automatically install BATS if it's not already present.
 - ✅ Symlink naming convention (e.g., `foo.symlink` → `~/.foo`)
 - ✅ Environment detection (Codespaces vs macOS)
 - ✅ All expected symlink files exist in the repository
+- ✅ Global Git config includes safely generated machine-local identity and credentials
 
 ### Install Script Tests
 - ✅ Install script finds all `install.sh` files

--- a/test/bootstrap.bats
+++ b/test/bootstrap.bats
@@ -29,8 +29,9 @@ teardown() {
 
 # Helper function to extract and source functions from bootstrap
 load_bootstrap_functions() {
-  # Extract the link_file function from bootstrap
-  sed -n '/^link_file ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" > "$TEST_DIR/functions.sh"
+  # Extract the functions under test from bootstrap
+  sed -n '/^setup_gitconfig ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" > "$TEST_DIR/functions.sh"
+  sed -n '/^link_file ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" >> "$TEST_DIR/functions.sh"
   sed -n '/^info ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" >> "$TEST_DIR/functions.sh"
   sed -n '/^success ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" >> "$TEST_DIR/functions.sh"
   sed -n '/^fail ()/,/^}/p' < "$DOTFILES_ROOT/bootstrap" >> "$TEST_DIR/functions.sh"
@@ -156,6 +157,39 @@ load_bootstrap_functions() {
 
 @test "gitconfig.local.symlink.example exists as template" {
   [ -f "$BATS_TEST_DIRNAME/../git/gitconfig.local.symlink.example" ]
+}
+
+@test "tracked gitconfig includes machine-local configuration without identity or credentials" {
+  local gitconfig="$BATS_TEST_DIRNAME/../git/gitconfig.symlink"
+
+  [ "$(git config --file "$gitconfig" --get include.path)" = "~/.gitconfig.local" ]
+  ! git config --file "$gitconfig" --get user.name
+  ! git config --file "$gitconfig" --get user.email
+  ! git config --file "$gitconfig" --get credential.helper
+  ! git config --file "$gitconfig" --get github.user
+  [ -n "$(git config --file "$gitconfig" --get alias.pushit)" ]
+}
+
+@test "setup_gitconfig safely writes special characters to valid local config" {
+  mkdir -p "$DOTFILES_ROOT/git"
+  cp "$BATS_TEST_DIRNAME/../git/gitconfig.local.symlink.example" "$DOTFILES_ROOT/git/"
+  load_bootstrap_functions
+
+  local author_name='Jamie / Shark & Co \ Team'
+  local author_email='jamie+dev&ops/example@example.com'
+  local expected_credential='cache'
+  if [ "$(uname -s)" = "Darwin" ]; then
+    expected_credential='osxkeychain'
+  fi
+
+  run setup_gitconfig <<< "$author_name"$'\n'"$author_email"
+
+  [ "$status" -eq 0 ]
+  local gitconfig="$DOTFILES_ROOT/git/gitconfig.local.symlink"
+  [ "$(git config --file "$gitconfig" --get user.name)" = "$author_name" ]
+  [ "$(git config --file "$gitconfig" --get user.email)" = "$author_email" ]
+  [ "$(git config --file "$gitconfig" --get credential.helper)" = "$expected_credential" ]
+  git config --file "$gitconfig" --list >/dev/null
 }
 
 @test "zsh install script exists" {


### PR DESCRIPTION
## Approach

- Include `~/.gitconfig.local` from the tracked global Git configuration.
- Remove tracked machine-specific GitHub identity, author identity, and credential-helper values.
- Generate the ignored local config through `git config` and an atomic temporary file so names and emails containing substitution-sensitive characters remain valid.
- Preserve the existing aliases and other global Git behavior.

## User impact

Bootstrap now keeps each machine’s Git author and credential helper in its local ignored configuration while the shared global configuration remains portable. Existing Git aliases continue to work unchanged.

## Validation

- `bash -n script/bootstrap test/bootstrap.bats`
- `./script/test` — all 41 BATS tests passed
- `git diff --check`
- `git config --file git/gitconfig.symlink --list`
- Isolated `HOME` validation confirmed the included local name, email, credential helper, and existing aliases resolve correctly with special characters.

Closes #20