### PR TITLE
fix(shell): correct PATH and platform detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ See [test/README.md](test/README.md) for more information about the test suite.
 - **powerlevel10k** theme with custom configuration
 - **Meslo Nerd Font** for proper glyph rendering
 - Custom aliases and environment settings
+- Platform-aware shell configuration across Apple Silicon, Intel macOS, and Linux
 - Auto-completion and syntax highlighting plugins
 
 # Other inspiration

--- a/homebrew/path.zsh
+++ b/homebrew/path.zsh
@@ -1,0 +1,3 @@
+if [[ "$(uname -s)" == "Darwin" ]] && (( $+commands[brew] )); then
+  eval "$(brew shellenv)"
+fi

--- a/node/path.zsh
+++ b/node/path.zsh
@@ -1,10 +1,3 @@
-if (( $+commands[npm] ))
-then
-  # Add npm bin
-  export PATH=/usr/local/bin/npm:$PATH
-else
-  if [ ! -z "$VERBOSE" ]
-  then
-    echo "npm not installed"
-  fi
+if (( ! $+commands[npm] )) && [[ -n "$VERBOSE" ]]; then
+  echo "npm not installed"
 fi

--- a/python/path.zsh
+++ b/python/path.zsh
@@ -1,11 +1,3 @@
-
-if (( $+commands[python] ))
-then
-  # Add python
-  export PATH=/usr/local/bin/python:$PATH
-else
-  if [ ! -z "$VERBOSE" ]
-  then
-    echo "Python not installed"
-  fi
+if (( ! $+commands[python] )) && [[ -n "$VERBOSE" ]]; then
+  echo "Python not installed"
 fi

--- a/system/_path.zsh
+++ b/system/_path.zsh
@@ -1,7 +1,16 @@
-# filename with underscore to load first
-PATH=/usr/local/bin:/usr/local/sbin:$ZSH/bin:$PATH
+# Keep PATH entries unique while preserving their first occurrence.
+typeset -gU path PATH
 
-# Add User `~/bin`
-PATH=$HOME/bin:$PATH
+for path_dir in \
+  /usr/local/sbin \
+  /usr/local/bin \
+  /opt/homebrew/sbin \
+  /opt/homebrew/bin \
+  "$ZSH/bin" \
+  "$HOME/bin"
+do
+  [[ -d "$path_dir" ]] && path=("$path_dir" $path)
+done
 
+unset path_dir
 export PATH

--- a/test/README.md
+++ b/test/README.md
@@ -27,6 +27,10 @@ The test script will automatically install BATS if it's not already present.
   - Verifies install.sh discovery mechanism
   - Tests individual component installers (homebrew, node, slate, zsh)
   - Validates script executability and error handling
+- **shell.bats** - Tests shell startup configuration
+  - Validates directory-only, duplicate-free PATH entries
+  - Verifies platform-specific Homebrew and alias loading
+  - Confirms missing optional runtimes do not cause startup errors
 
 ## What the Tests Verify
 

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+  export REPO_ROOT="$BATS_TEST_DIRNAME/.."
+  export TEST_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "PATH configuration keeps existing directories unique" {
+  mkdir -p "$TEST_DIR/home/bin" "$TEST_DIR/zsh/bin"
+
+  run env HOME="$TEST_DIR/home" ZSH="$TEST_DIR/zsh" \
+    zsh -c 'PATH="$HOME/bin:/usr/bin:/usr/bin"; source "$1"; print -r -- "$PATH"' \
+    zsh "$REPO_ROOT/system/_path.zsh"
+
+  [ "$status" -eq 0 ]
+  [ "${output%%:*}" = "$TEST_DIR/home/bin" ]
+  [ "$(tr ':' '\n' <<< "$output" | sort | uniq -d)" = "" ]
+
+  while IFS= read -r directory; do
+    [ -d "$directory" ]
+  done < <(tr ':' '\n' <<< "$output")
+}
+
+@test "PATH configuration supports Apple Silicon and Intel Homebrew" {
+  grep -Fq "/opt/homebrew/bin" "$REPO_ROOT/system/_path.zsh"
+  grep -Fq "/usr/local/bin" "$REPO_ROOT/system/_path.zsh"
+}
+
+@test "Homebrew shell environment loads on macOS from PATH" {
+  mkdir -p "$TEST_DIR/bin"
+  cat > "$TEST_DIR/bin/uname" <<'EOF'
+#!/bin/sh
+echo Darwin
+EOF
+  cat > "$TEST_DIR/bin/brew" <<'EOF'
+#!/bin/sh
+echo 'export HOMEBREW_TEST=loaded'
+EOF
+  chmod +x "$TEST_DIR/bin/uname" "$TEST_DIR/bin/brew"
+
+  run env PATH="$TEST_DIR/bin:/usr/bin" /bin/zsh -c \
+    'source "$1"; print -r -- "$HOMEBREW_TEST"' zsh "$REPO_ROOT/homebrew/path.zsh"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "loaded" ]
+}
+
+@test "Homebrew shell environment is skipped outside macOS" {
+  mkdir -p "$TEST_DIR/bin"
+  cat > "$TEST_DIR/bin/uname" <<'EOF'
+#!/bin/sh
+echo Linux
+EOF
+  cat > "$TEST_DIR/bin/brew" <<'EOF'
+#!/bin/sh
+echo 'exit 42'
+EOF
+  chmod +x "$TEST_DIR/bin/uname" "$TEST_DIR/bin/brew"
+
+  run env PATH="$TEST_DIR/bin:/usr/bin" /bin/zsh -c 'source "$1"' \
+    zsh "$REPO_ROOT/homebrew/path.zsh"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "macOS-only aliases are not exposed on Linux" {
+  mkdir -p "$TEST_DIR/bin"
+  cat > "$TEST_DIR/bin/uname" <<'EOF'
+#!/bin/sh
+echo Linux
+EOF
+  chmod +x "$TEST_DIR/bin/uname"
+
+  run env PATH="$TEST_DIR/bin:/usr/bin:/bin" zsh -c \
+    'source "$1"; alias f flushDNS ipInfo0 ipInfo1 showBlocked' \
+    zsh "$REPO_ROOT/zsh/aliases"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"open -a Finder"* ]]
+  [[ "$output" != *"dscacheutil"* ]]
+}
+
+@test "missing optional runtimes do not cause startup errors" {
+  run env PATH="/usr/bin:/bin" VERBOSE= zsh -c \
+    'source "$1"; source "$2"; source "$3"; source "$4"' \
+    zsh \
+    "$REPO_ROOT/node/path.zsh" \
+    "$REPO_ROOT/python/path.zsh" \
+    "$REPO_ROOT/yarn/path.zsh" \
+    "$REPO_ROOT/ruby/rbenv.zsh"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/yarn/path.zsh
+++ b/yarn/path.zsh
@@ -1,11 +1,9 @@
 # https://yarnpkg.com
 
-if (( $+commands[yarn] ))
-then
-  export PATH="$PATH:`yarn global bin`"
-else
-  if [ ! -z "$VERBOSE" ]
-  then
-    echo "yarn not installed"
-  fi
+if (( $+commands[yarn] )); then
+  yarn_bin="$(yarn global bin 2>/dev/null)" || yarn_bin=
+  [[ -d "$yarn_bin" ]] && path+=("$yarn_bin")
+  unset yarn_bin
+elif [[ -n "$VERBOSE" ]]; then
+  echo "yarn not installed"
 fi

--- a/zsh/aliases
+++ b/zsh/aliases
@@ -47,7 +47,6 @@ alias .3='cd ../../../'                     # Go back 3 directory levels
 alias .4='cd ../../../../'                  # Go back 4 directory levels
 alias .5='cd ../../../../../'               # Go back 5 directory levels
 alias .6='cd ../../../../../../'            # Go back 6 directory levels
-alias f='open -a Finder ./'                 # f: Opens current directory in MacOS Finder
 alias ~="cd ~"                              # ~: o Home
 
 #   lr:  Full Recursive Directory Listing
@@ -60,28 +59,31 @@ alias lr='ls -R | grep ":$" | sed -e '\''s/:$//'\'' -e '\''s/[^-][^\/]*\//--/g'\
 
 alias myip="curl -s checkip.dyndns.org | sed -e 's/.*Current IP Address: //' -e 's/<.*$//'                " # myip:         Public facing IP Address
 alias netCons='lsof -i'                             # netCons:      Show all open TCP/IP sockets
-alias flushDNS='dscacheutil -flushcache'            # flushDNS:     Flush out the DNS Cache
 alias lsock='sudo /usr/sbin/lsof -i -P'             # lsock:        Display open sockets
 alias lsockU='sudo /usr/sbin/lsof -nP | grep UDP'   # lsockU:       Display only open UDP sockets
 alias lsockT='sudo /usr/sbin/lsof -nP | grep TCP'   # lsockT:       Display only open TCP sockets
-alias ipInfo0='ipconfig getpacket en0'              # ipInfo0:      Get info on connections for en0
-alias ipInfo1='ipconfig getpacket en1'              # ipInfo1:      Get info on connections for en1
 alias openPorts='sudo lsof -i | grep LISTEN'        # openPorts:    All listening connections
-alias showBlocked='sudo ipfw list'                  # showBlocked:  All ipfw rules inc/ blocked IPs
 
-# ii: display useful host related informaton
-# -------------------------------------------------------------------
-ii() {
-  echo -e "\nYou are logged on ${RED}$HOST"
-  echo -e "\nAdditionnal information:$NC " ; uname -a
-  echo -e "\n${RED}Users logged on:$NC " ; w -h
-  echo -e "\n${RED}Current date :$NC " ; date
-  echo -e "\n${RED}Machine stats :$NC " ; uptime
-  echo -e "\n${RED}Current network location :$NC " ; scselect
-  echo -e "\n${RED}Public facing IP Address :$NC " ;myip
-  echo -e "\n${RED}DNS Configuration:$NC " ; scutil --dns
-  echo
-}
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  alias f='open -a Finder ./'
+  alias flushDNS='dscacheutil -flushcache'
+  alias ipInfo0='ipconfig getpacket en0'
+  alias ipInfo1='ipconfig getpacket en1'
+  alias showBlocked='sudo ipfw list'
+
+  # ii: display useful host related information
+  ii() {
+    echo -e "\nYou are logged on ${RED}$HOST"
+    echo -e "\nAdditional information:$NC " ; uname -a
+    echo -e "\n${RED}Users logged on:$NC " ; w -h
+    echo -e "\n${RED}Current date :$NC " ; date
+    echo -e "\n${RED}Machine stats :$NC " ; uptime
+    echo -e "\n${RED}Current network location :$NC " ; scselect
+    echo -e "\n${RED}Public facing IP Address :$NC " ; myip
+    echo -e "\n${RED}DNS Configuration:$NC " ; scutil --dns
+    echo
+  }
+fi
 
 #   ---------------------------
 #   3. DEV SHORTCUTS

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -45,21 +45,22 @@ else
   # Load: p10k theme
   [[ ! -f $DOTFILES/zsh/.p10k.zsh ]] || source $DOTFILES/zsh/.p10k.zsh
 
-  # homebrew
-  eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
+# Load PATH configuration first.
+source "$DOTFILES/system/_path.zsh"
+
 # Load: aliases
-source $DOTFILES/zsh/aliases
+source "$DOTFILES/zsh/aliases"
 
 # Load: env
-source $DOTFILES/zsh/env
+source "$DOTFILES/zsh/env"
 
 # find everything but path files and completion files and load them
 config_files=($DOTFILES/**/*.zsh)
 for file in ${${config_files:#*/_path.zsh}:#*/completion.zsh}
 do
-  source $file
+  source "$file"
 done
 
 autoload -U compinit promptinit; compinit promptinit


### PR DESCRIPTION
## Approach

- Build `PATH` from existing directories with zsh uniqueness semantics so entries remain valid and deduplicated.
- Support both `/opt/homebrew` and `/usr/local` Homebrew prefixes, initializing Homebrew only on macOS when `brew` is available.
- Stop adding npm and Python executable paths; their containing `bin` directories remain on `PATH`.
- Gate Finder, DNS, network-interface, firewall, and macOS system-information helpers to Darwin.
- Keep optional npm, Python, Yarn, and rbenv configuration quiet when those runtimes are unavailable.
- Add targeted BATS coverage and update directly related shell documentation.

## User impact

`node`, `npm`, Python, Yarn, and Homebrew commands continue to work directly when installed. Shell startup no longer gains invalid or duplicate PATH entries, Intel and Apple Silicon Homebrew installations are supported, and Codespaces/Linux sessions do not expose macOS-only aliases.

## Validation

- `./script/test` — 45/45 tests passed
- `zsh -n system/_path.zsh homebrew/path.zsh node/path.zsh python/path.zsh yarn/path.zsh ruby/rbenv.zsh zsh/aliases zsh/zshrc.symlink`
- `git diff --check`

Closes #18